### PR TITLE
Change "apache-2.0 or bsd" to map apache_license_v2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.2.10 (2025-03-19)
+
+- Change "apache-2.0 or bsd" to map apache_license_v2, instead of BSD 2-clause license. Because bsd can refer to 4-clause too but apache-2.0 is more likely to be one you want to use
+
 ## 0.2.9 (2025-03-12)
 
 - Improve the error message for UNKOWN license

--- a/src/license_scanner/__init__.py
+++ b/src/license_scanner/__init__.py
@@ -2,7 +2,7 @@
 """Scans your environment for all needed licenses"""
 
 __author__ = """Tom Nijhof"""
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 # Add here import to all the functions you need
 

--- a/src/license_scanner/parse_license/licenses_synonyms.py
+++ b/src/license_scanner/parse_license/licenses_synonyms.py
@@ -112,7 +112,7 @@ LICENSES_SYNONYMS = {
     "bsd (3-clause)": bsd_license_c3,
     "bsd 2-clause (see license file)": bsd_license_c2,
     "bsd 3 clause": bsd_license_c3,
-    "apache-2.0 or bsd": bsd_license_c2,
+    "apache-2.0 or bsd": apache_license_v2,
     "3-clause bsd <http://www.opensource.org/licenses/bsd-license.php>": bsd_license_c3,
     "bsd 3-clause license": bsd_license_c3,
     "3-clause bsd": bsd_license_c3,


### PR DESCRIPTION
Thank you for your contribution to the **license_scanner** package.
Before submitting/accepting this Pull Request, please make sure:

## Contributor of code

- [x] Functions are named based on [Python naming conventions](https://visualgit.readthedocs.io/en/latest/pages/naming_convention.html)
- [x] Explain how to run the code `(docstring)`
- [ ] Function is tested
- [x] All needed package are in [pyproject.toml](pyproject.toml)
- [x] Version number is updated
- [x] `HISTORY.rst` is updated
- [x] New feature is added to `README.md`
- [x] New license is added to `README.md` subsection `Supported licenses`

## Reviewer

- [ ] Functions are named based on [Python naming conventions](https://visualgit.readthedocs.io/en/latest/pages/naming_convention.html)
- [ ] Explain how to run the code `(docstring)`
- [ ] Function is tested
- [ ] All needed package are in [pyproject.toml](pyproject.toml)
- [ ] Version number is updated
- [ ] `HISTORY.rst` is updated
- [ ] New feature is added to `README.md`
- [ ] New license is added to `README.md` subsection `Supported licenses`
